### PR TITLE
Make the plugin compatible with node < 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = postcss.plugin('postcss-viewport-units', options => (root, resu
   const test = opts.test || (value => regViewportUnit.test(value));
 
   root.walkRules((rule) => {
-    let hasContent;
+    var hasContent;
     const viewportUnitDecls = [];
 
     rule.nodes.slice(0).forEach((decl) => {


### PR DESCRIPTION
I am using node v4 and I am getting the following:
```
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

The proposed change would make this package work in node < 6.